### PR TITLE
fix error that occurs in `changeFocus` if there is no active window

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -229,10 +229,7 @@ class FocusChanger {
             }
         }
 
-        if (focusedWindow)
-            return { activeWindow: focusedWindow, activeRect: focusedWindowRect };
-        else
-            return null;
+        return { activeWindow: focusedWindow, activeRect: focusedWindowRect };
     }
 
     _bindShortcut() {


### PR DESCRIPTION
Hi! I really enjoy the spatial navigation that this extension provides!

I encountered an error when doing some testing that I think might interfere with the operation of the extension. The issue is an uncaught error that comes up if one of the key bindings is activated while there is no active window. `_getActiveWindow()` can return `null` - when that happens the attempt to destructure `null` causes a crash.

The fix I propose here is to return an object from `_getActiveWindow()` regardless of whether an active window was found. If there is no focused window then the `activeWindow` and `activeRect` properties of the returned object are `null`.