### PR TITLE
fix error in settings UI on undefined accelerator

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -100,7 +100,7 @@ function addKeybinding(model, settings, id, description) {
     // Get the current accelerator.
     let accelerator = settings.get_strv(id)[0];
     let key, mods;
-    if (accelerator == null)
+    if (!accelerator)
         [key, mods] = [0, 0];
     else
         [, key, mods] = Gtk.accelerator_parse(accelerator);

--- a/prefs.js
+++ b/prefs.js
@@ -100,10 +100,10 @@ function addKeybinding(model, settings, id, description) {
     // Get the current accelerator.
     let accelerator = settings.get_strv(id)[0];
     let key, mods;
-    if (accelerator === null)
+    if (accelerator == null)
         [key, mods] = [0, 0];
     else
-        [, key, mods] = Gtk.accelerator_parse(settings.get_strv(id)[0]);
+        [, key, mods] = Gtk.accelerator_parse(accelerator);
 
     let row = model.insert(100);
     model.set(row, [COLUMN_ID, COLUMN_DESC, COLUMN_KEY, COLUMN_MODS], [id, description, key, mods]);


### PR DESCRIPTION
The error comes up when one of the keyboard shortcuts has been unset
in which case the settings UI is no longer usable.

This changes the check for a `null` accelerator to catch either `null`
or `undefined`. The triple-equals operator, `=== null`, does not allow
type coercion, and will only match `null`. On the other hand the
double-equals operator, `== null`, *does* allow type coercion and as
a result considers `null` and `undefined` to be equivalent. (Although
`null` and `undefined` are isomorphic to each other, they are considered
to be distinct values which makes them distinct under strict equality
checks.)

Another option would be to check for falsy values: `if (!accelerator) {...}`
That catches `null`, `undefined`, and empty strings which you probably
want to treat the same anyway.

Fixes #3