### PR TITLE
Add support for GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Change focus between windows in all directions.\n\nThe extension will first try to find a suitable window within the same monitor. If there is none, it will try to find one on the next monitor in that direction (in a multi-monitor setup).\n\nDefault shortcuts (can be changed in preferences):\n<Super>+h = Focus left\n<Super>+j = Focus down\n<Super>+k = Focus up\n<Super>+l = Focus right",
   "uuid": "focus-changer@heartmire",
   "version": 1.1,
-  "shell-version": ["40", "41", "42", "43"],
+  "shell-version": ["40", "41", "42", "43", "44"],
   "url": "https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer"
 }


### PR DESCRIPTION
I've added the "44" tag to the `metadata.json` file of my local installation of Focus Changer and I've been using a it on GNOME 44 for a few days without any issues.

Thanks for developing this extension! 🚀 