### PR TITLE
Add support for GNOME 45 and i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+focus-changer@heartmire.shell-extension.zip

--- a/extension.js
+++ b/extension.js
@@ -60,7 +60,7 @@ export default class FocusChanger extends Extension {
                         bestMonitorCandidate = m;
                     else if (
                         Math.abs(activeMonitor.x - m.rect.x) <
-              Math.abs(activeMonitor.x - bestMonitorCandidate.rect.x)
+                        Math.abs(activeMonitor.x - bestMonitorCandidate.rect.x)
                     )
                         bestMonitorCandidate = m;
                 }
@@ -73,7 +73,7 @@ export default class FocusChanger extends Extension {
                         bestMonitorCandidate = m;
                     else if (
                         Math.abs(activeMonitor.x - m.rect.x) <
-              Math.abs(activeMonitor.x - bestMonitorCandidate.rect.x)
+                        Math.abs(activeMonitor.x - bestMonitorCandidate.rect.x)
                     )
                         bestMonitorCandidate = m;
                 }
@@ -86,7 +86,7 @@ export default class FocusChanger extends Extension {
                         bestMonitorCandidate = m;
                     else if (
                         Math.abs(activeMonitor.y - m.rect.y) <
-              Math.abs(activeMonitor.y - bestMonitorCandidate.rect.y)
+                        Math.abs(activeMonitor.y - bestMonitorCandidate.rect.y)
                     )
                         bestMonitorCandidate = m;
                 }
@@ -99,7 +99,7 @@ export default class FocusChanger extends Extension {
                         bestMonitorCandidate = m;
                     else if (
                         Math.abs(activeMonitor.y - m.rect.y) <
-              Math.abs(activeMonitor.y - bestMonitorCandidate.rect.y)
+                        Math.abs(activeMonitor.y - bestMonitorCandidate.rect.y)
                     )
                         bestMonitorCandidate = m;
                 }

--- a/extension.js
+++ b/extension.js
@@ -113,24 +113,34 @@ export default class FocusChanger extends Extension {
         return null;
     }
 
+    _getCenterX(rect){
+        return rect.x + rect.width/2;
+    }
+
+    _getCenterY(rect){
+        return rect.y - rect.height/2;
+    }
+
     _getBestCandidate(id, monitor, activeRect) {
         const windows = this._getAllWindows(monitor);
-        const { x, y } = activeRect;
+        const x = this._getCenterX(activeRect);
+        const y = this._getCenterY(activeRect);
         let bestCandidate = null;
+
         switch (id) {
         case SCHEMA_FOCUS_UP:
             windows.forEach(w => {
                 const rect = w.get_frame_rect();
-                if (rect.y < y) {
+                if (this._getCenterY(rect) < y) {
                     if (!bestCandidate) {
                         bestCandidate = w;
                     } else {
                         const bestRect = bestCandidate.get_frame_rect();
-                        if (rect.x === bestRect.x && rect.y > bestRect.y)
+                        if (this._getCenterX(rect) === this._getCenterX(bestRect) && this._getCenterY(rect) > this.getCenterY(bestRect))
                             bestCandidate = w;
                         else if (
-                            rect.x !== bestRect.x &&
-                Math.abs(activeRect.x - rect.x) < Math.abs(activeRect.x - bestRect.x)
+                            this._getCenterX(rect) !== this._getCenterX(bestRect) &&
+                            Math.abs(x - this._getCenterX(rect)) < Math.abs(x - this._getCenterX(bestRect))
                         )
                             bestCandidate = w;
                     }
@@ -140,16 +150,16 @@ export default class FocusChanger extends Extension {
         case SCHEMA_FOCUS_DOWN:
             windows.forEach(w => {
                 const rect = w.get_frame_rect();
-                if (rect.y > y) {
+                if (this._getCenterY(rect) > y) {
                     if (!bestCandidate) {
                         bestCandidate = w;
                     } else {
                         const bestRect = bestCandidate.get_frame_rect();
-                        if (rect.x === bestRect.x && rect.y < bestRect.y)
+                        if (this._getCenterX(rect) === this._getCenterX(bestRect) && this._getCenterY(rect) < this.getCenterY(bestRect))
                             bestCandidate = w;
                         else if (
-                            rect.x !== bestRect.x &&
-                Math.abs(activeRect.x - rect.x) < Math.abs(activeRect.x - bestRect.x)
+                            this._getCenterX(rect) !== this._getCenterX(bestRect) &&
+                            Math.abs(x - this._getCenterX(rect)) < Math.abs(x - this._getCenterX(bestRect))
                         )
                             bestCandidate = w;
                     }
@@ -159,16 +169,16 @@ export default class FocusChanger extends Extension {
         case SCHEMA_FOCUS_RIGHT:
             windows.forEach(w => {
                 const rect = w.get_frame_rect();
-                if (rect.x > x) {
+                if (this._getCenterX(rect) > x) {
                     if (!bestCandidate) {
                         bestCandidate = w;
                     } else {
                         const bestRect = bestCandidate.get_frame_rect();
-                        if (rect.y === bestRect.y && rect.x < bestRect.x)
+                        if (this._getCenterY(rect) === this.getCenterY(bestRect) && this._getCenterX(rect) < this._getCenterX(bestRect))
                             bestCandidate = w;
                         else if (
-                            rect.y !== bestRect.y &&
-                Math.abs(activeRect.y - rect.y) < Math.abs(activeRect.y - bestRect.y)
+                            this._getCenterY(rect) !== this.getCenterY(bestRect) &&
+                            Math.abs(y - this.getCenterY(rect)) < Math.abs(this.getCenterY(activeRect) - this.getCenterY(bestRect))
                         )
                             bestCandidate = w;
                     }
@@ -178,16 +188,16 @@ export default class FocusChanger extends Extension {
         case SCHEMA_FOCUS_LEFT:
             windows.forEach(w => {
                 const rect = w.get_frame_rect();
-                if (rect.x < x) {
+                if (this._getCenterX(rect) < x) {
                     if (!bestCandidate) {
                         bestCandidate = w;
                     } else {
                         const bestRect = bestCandidate.get_frame_rect();
-                        if (rect.y === bestRect.y && rect.x > bestRect.x)
+                        if (this._getCenterY(rect) === this.getCenterY(bestRect) && this._getCenterX(rect) > this._getCenterX(bestRect))
                             bestCandidate = w;
                         else if (
-                            rect.y !== bestRect.y &&
-                Math.abs(activeRect.y - rect.y) < Math.abs(activeRect.y - bestRect.y)
+                            this._getCenterY(rect) !== this.getCenterY(bestRect) &&
+                            Math.abs(y - this.getCenterY(rect)) < Math.abs(this.getCenterY(activeRect) - this.getCenterY(bestRect))
                         )
                             bestCandidate = w;
                     }

--- a/extension.js
+++ b/extension.js
@@ -1,17 +1,20 @@
 'use strict';
 
-const { Shell, Meta } = imports.gi;
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Shell from 'gi://Shell';
+import Meta from 'gi://Meta';
+
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 const SCHEMA_FOCUS_UP = 'focus-up';
 const SCHEMA_FOCUS_DOWN = 'focus-down';
 const SCHEMA_FOCUS_RIGHT = 'focus-right';
 const SCHEMA_FOCUS_LEFT = 'focus-left';
 
-class FocusChanger {
-    constructor() {
+export default class FocusChanger extends Extension {
+    constructor(metadata) {
+        super(metadata);
         this._workspaceManager = global.workspace_manager;
         this._keyFocusUpId = null;
         this._keyFocusDownId = null;
@@ -284,7 +287,7 @@ class FocusChanger {
     }
 
     enable() {
-        this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.focus-changer');
+        this._settings = this.getSettings('org.gnome.shell.extensions.focus-changer');
         this._bindShortcut();
     }
 
@@ -292,9 +295,4 @@ class FocusChanger {
         this._unbindShortcut();
         this._settings = null;
     }
-}
-
-// eslint-disable-next-line no-unused-vars
-function init() {
-    return new FocusChanger();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,8 @@
   "shell-version": ["45"],
   "url": "https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer",
   "settings-schema": "org.gnome.shell.extensions.focus-changer",
-  "gettext-domain": "focus-changer@heartmire"
+  "gettext-domain": "focus-changer@heartmire",
+  "donations": {
+      "kofi": "heartmire"
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "name": "Focus changer",
   "description": "Change focus between windows in all directions.\n\nThe extension will first try to find a suitable window within the same monitor. If there is none, it will try to find one on the next monitor in that direction (in a multi-monitor setup).\n\nDefault shortcuts (can be changed in preferences):\n<Super>+h = Focus left\n<Super>+j = Focus down\n<Super>+k = Focus up\n<Super>+l = Focus right",
   "uuid": "focus-changer@heartmire",
-  "version": 1.1,
-  "shell-version": ["40", "41", "42", "43", "44"],
-  "url": "https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer"
+  "version": 15,
+  "shell-version": ["45"],
+  "url": "https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer",
+  "settings-schema": "org.gnome.shell.extensions.focus-changer"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,6 @@
   "version": 15,
   "shell-version": ["45"],
   "url": "https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer",
-  "settings-schema": "org.gnome.shell.extensions.focus-changer"
+  "settings-schema": "org.gnome.shell.extensions.focus-changer",
+  "gettext-domain": "focus-changer@heartmire"
 }

--- a/po/focus-changer@heartmire.pot
+++ b/po/focus-changer@heartmire.pot
@@ -1,0 +1,46 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-09-30 21:31-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:15
+msgid "Focus changer"
+msgstr ""
+
+#: prefs.js:19
+msgid "Shortcuts"
+msgstr ""
+
+#: prefs.js:26
+msgid "Focus up"
+msgstr ""
+
+#: prefs.js:30
+msgid "Focus down"
+msgstr ""
+
+#: prefs.js:34
+msgid "Focus left"
+msgstr ""
+
+#: prefs.js:38
+msgid "Focus right"
+msgstr ""
+
+#: prefs.js:66
+msgid "Press the shortcut for this action"
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,47 @@
+# Portuguese translations for PACKAGE package
+# Traduções em português brasileiro para o pacote PACKAGE.
+# Copyright (C) 2023 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Pedro Sader Azevedo <email@pesader.dev>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 15\n"
+"Report-Msgid-Bugs-To: https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer\n"
+"POT-Creation-Date: 2023-09-30 21:31-0300\n"
+"PO-Revision-Date: 2023-09-30 21:33-0300\n"
+"Last-Translator: Pedro Sader Azevedo <email@pesader.dev>\n"
+"Language-Team: Brazilian Portuguese\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: prefs.js:15
+msgid "Focus changer"
+msgstr ""
+
+#: prefs.js:19
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: prefs.js:26
+msgid "Focus up"
+msgstr "Focar acima"
+
+#: prefs.js:30
+msgid "Focus down"
+msgstr "Focar abaixo"
+
+#: prefs.js:34
+msgid "Focus left"
+msgstr "Focar à esquerda"
+
+#: prefs.js:38
+msgid "Focus right"
+msgstr "Focar à direita"
+
+#: prefs.js:66
+msgid "Press the shortcut for this action"
+msgstr "Pressione o atalho para esta ação"

--- a/prefs.js
+++ b/prefs.js
@@ -6,6 +6,36 @@ import Adw from "gi://Adw";
 
 import { ExtensionPreferences,  gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
+const keyvalIsForbidden$1 = (keyval) => {
+    return [
+        Gdk.KEY_Home,
+        Gdk.KEY_Page_Up,
+        Gdk.KEY_Page_Down,
+        Gdk.KEY_End,
+        Gdk.KEY_Tab,
+        Gdk.KEY_KP_Enter,
+        Gdk.KEY_Return,
+        Gdk.KEY_Mode_switch,
+        Gdk.KEY_Space,
+    ].includes(keyval);
+};
+
+const isValidAccel$1 = (mask, keyval) => {
+    return (
+        Gtk.accelerator_valid(keyval, mask) ||
+        (keyval === Gdk.KEY_Tab && mask !== 0)
+    );
+};
+
+const isValidBinding$1 = (mask, keycode, keyval) => {
+    return (
+        mask !== 0 &&
+        keycode !== 0 &&
+        mask & ~(Gdk.ModifierType.SHIFT_MASK) &&
+        !(keyvalIsForbidden$1(keyval))
+    );
+};
+
 export default class FocusChangerPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
         window._settings = this.getSettings();
@@ -119,35 +149,5 @@ export default class FocusChangerPreferences extends ExtensionPreferences {
         });
 
         window.add(page);
-    };
-};
-
-const keyvalIsForbidden$1 = (keyval) => {
-    return [
-        Gdk.KEY_Home,
-        Gdk.KEY_Page_Up,
-        Gdk.KEY_Page_Down,
-        Gdk.KEY_End,
-        Gdk.KEY_Tab,
-        Gdk.KEY_KP_Enter,
-        Gdk.KEY_Return,
-        Gdk.KEY_Mode_switch,
-        Gdk.KEY_Space,
-    ].includes(keyval);
-};
-
-const isValidAccel$1 = (mask, keyval) => {
-    return (
-        Gtk.accelerator_valid(keyval, mask) ||
-        (keyval === Gdk.KEY_Tab && mask !== 0)
-    );
-};
-
-const isValidBinding$1 = (mask, keycode, keyval) => {
-    return (
-        mask !== 0 &&
-        keycode !== 0 &&
-        mask & ~(Gdk.ModifierType.SHIFT_MASK) &&
-        !(keyvalIsForbidden$1(keyval))
-    );
-};
+    }
+}

--- a/prefs.js
+++ b/prefs.js
@@ -4,7 +4,7 @@ import Gdk from "gi://Gdk";
 import Gtk from 'gi://Gtk';
 import Adw from "gi://Adw";
 
-import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { ExtensionPreferences,  gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class FocusChangerPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
@@ -12,30 +12,30 @@ export default class FocusChangerPreferences extends ExtensionPreferences {
         window.set_default_size(650, 400);
 
         const page = Adw.PreferencesPage.new();
-        page.set_title(("Focus changer"));
+        page.set_title(_("Focus changer"));
         page.set_name("focus-changer-preferences");
 
         const group = Adw.PreferencesGroup.new();
-        group.set_title(("Shortcuts"));
+        group.set_title(_("Shortcuts"));
         group.set_name("shortcuts_group");
         page.add(group);
 
         let schemas = [
             {
                 id: "focus-up",
-                title: "Focus up",
+                title: _("Focus up"),
             },
             {
                 id: "focus-down",
-                title: "Focus down",
+                title: _("Focus down"),
             },
             {
                 id: "focus-left",
-                title: "Focus left",
+                title: _("Focus left"),
             },
             {
                 id: "focus-right",
-                title: "Focus right",
+                title: _("Focus right"),
             },
         ]
 
@@ -63,7 +63,7 @@ export default class FocusChangerPreferences extends ExtensionPreferences {
 
                 const content = new Adw.StatusPage({
                     title: schema.title,
-                    description: (`Press the shortcut for this action`),
+                    description: _("Press the shortcut for this action"),
                     icon_name: "preferences-desktop-keyboard-shortcuts-symbolic",
                 });
 

--- a/prefs.js
+++ b/prefs.js
@@ -1,110 +1,153 @@
 'use strict';
 
-const Gtk = imports.gi.Gtk;
-const GObject = imports.gi.GObject;
-const ExtensionUtils = imports.misc.extensionUtils;
+import Gdk from "gi://Gdk";
+import Gtk from 'gi://Gtk';
+import Adw from "gi://Adw";
 
-const COLUMN_ID = 0;
-const COLUMN_DESC = 1;
-const COLUMN_KEY = 2;
-const COLUMN_MODS = 3;
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-// eslint-disable-next-line no-unused-vars
-function init() {}
+export default class FocusChangerPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        window._settings = this.getSettings();
+        window.set_default_size(650, 400);
 
-// eslint-disable-next-line no-unused-vars
-function buildPrefsWidget() {
-    const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.focus-changer');
+        const page = Adw.PreferencesPage.new();
+        page.set_title(("Focus changer"));
+        page.set_name("focus-changer-preferences");
 
-    const prefsWidget = new Gtk.Grid({
-        margin_top: 20,
-        margin_bottom: 20,
-        margin_start: 20,
-        margin_end: 20,
-        row_spacing: 20,
-    });
+        const group = Adw.PreferencesGroup.new();
+        group.set_title(("Shortcuts"));
+        group.set_name("shortcuts_group");
+        page.add(group);
 
-    const keybindingLabel = new Gtk.Label({
-        label: 'Keyboard shortcuts',
-        hexpand: true,
-        halign: Gtk.Align.START,
-    });
-    prefsWidget.attach(keybindingLabel, 0, 0, 1, 1);
+        let schemas = [
+            {
+                id: "focus-up",
+                title: "Focus up",
+            },
+            {
+                id: "focus-down",
+                title: "Focus down",
+            },
+            {
+                id: "focus-left",
+                title: "Focus left",
+            },
+            {
+                id: "focus-right",
+                title: "Focus right",
+            },
+        ]
 
-    // Setup the store
-    let store = new Gtk.ListStore();
-    store.set_column_types([
-        GObject.TYPE_STRING, // COLUMN_ID
-        GObject.TYPE_STRING, // COLUMN_DESC
-        GObject.TYPE_INT, // COLUMN_KEY
-        GObject.TYPE_INT, // COLUMN_MODS
-    ]);
+        schemas.forEach(schema => {
+            const row = new Adw.ActionRow({
+                title: schema.title,
+                // subtitle: ("Shortcut to focus on the window above"),
+            });
 
-    addKeybinding(store, settings, 'focus-up', 'Focus up');
-    addKeybinding(store, settings, 'focus-down', 'Focus down');
-    addKeybinding(store, settings, 'focus-left', 'Focus left');
-    addKeybinding(store, settings, 'focus-right', 'Focus right');
+            const shortcutLabel = new Gtk.ShortcutLabel({
+                disabled_text: ("Select a shortcut"),
+                accelerator: window._settings.get_strv(schema.id)[0],
+                valign: Gtk.Align.CENTER,
+                halign: Gtk.Align.CENTER,
+            });
 
-    let treeView = new Gtk.TreeView();
-    treeView.model = store;
-    treeView.headers_visible = false;
+            window._settings.connect(`changed::${schema.id}`, () => {
+                shortcutLabel.set_accelerator(
+                    window._settings.get_strv(schema.id)[0]
+                );
+            });
 
-    // Desc text
-    let renderer, column;
-    renderer = new Gtk.CellRendererText();
-    column = new Gtk.TreeViewColumn();
-    column.expand = true;
-    column.pack_start(renderer, true);
-    column.add_attribute(renderer, 'text', COLUMN_DESC);
-    treeView.append_column(column);
+            row.connect("activated", () => {
+                const ctl = new Gtk.EventControllerKey();
 
-    // Key binding
-    renderer = new Gtk.CellRendererAccel();
-    renderer.accel_mode = Gtk.CellRendererAccelMode.GTK;
-    renderer.editable = true;
-    column = new Gtk.TreeViewColumn();
-    column.pack_end(renderer, false);
-    column.add_attribute(renderer, 'accel-key', COLUMN_KEY);
-    column.add_attribute(renderer, 'accel-mods', COLUMN_MODS);
-    treeView.append_column(column);
-    prefsWidget.attach(treeView, 0, 1, 2, 1);
+                const content = new Adw.StatusPage({
+                    title: schema.title,
+                    description: (`Press the shortcut for this action`),
+                    icon_name: "preferences-desktop-keyboard-shortcuts-symbolic",
+                });
 
-    // Events
-    renderer.connect('accel-edited', (_, path, key, mods, __) => {
-        let [ok, iter] = store.get_iter_from_string(path);
-        if (!ok)
-            return;
+                const editor = new Adw.Window({
+                    modal: true,
+                    transient_for: page.get_root(),
+                    hide_on_close: true,
+                    width_request: 320,
+                    height_request: 240,
+                    resizable: false,
+                    content,
+                });
 
-        store.set(iter, [COLUMN_KEY, COLUMN_MODS], [key, mods]);
+                editor.add_controller(ctl);
+                ctl.connect("key-pressed", (_, keyval, keycode, state) => {
+                    let mask = state & Gtk.accelerator_get_default_mod_mask();
+                    mask &= ~Gdk.ModifierType.LOCK_MASK;
 
-        let id = store.get_value(iter, COLUMN_ID);
-        let accelString = Gtk.accelerator_name(key, mods);
-        settings.set_strv(id, [accelString]);
-    });
+                    if (
+                        !mask &&
+                        (keyval === Gdk.KEY_Escape || keyval === Gdk.KEY_BackSpace)
+                    ) {
+                        editor.close();
+                        return Gdk.EVENT_STOP;
+                    }
 
-    renderer.connect('accel-cleared', (_, path) => {
-        let [ok, iter] = store.get_iter_from_string(path);
-        if (!ok)
-            return;
+                    if (
+                        !isValidBinding$1(mask, keycode, keyval) ||
+                        !isValidAccel$1(mask, keyval)
+                    ) {
+                        return Gdk.EVENT_STOP;
+                    }
 
-        store.set(iter, [COLUMN_KEY, COLUMN_MODS], [0, 0]);
+                    window._settings.set_strv(schema.id, [
+                        Gtk.accelerator_name_with_keycode(
+                            null,
+                            keyval,
+                            keycode,
+                            mask
+                        ),
+                    ]);
 
-        let id = store.get_value(iter, COLUMN_ID);
-        settings.set_strv(id, []);
-    });
+                    editor.destroy();
+                    return Gdk.EVENT_STOP;
+                });
 
-    return prefsWidget;
-}
+                editor.present();
+            });
 
-function addKeybinding(model, settings, id, description) {
-    // Get the current accelerator.
-    let accelerator = settings.get_strv(id)[0];
-    let key, mods;
-    if (!accelerator)
-        [key, mods] = [0, 0];
-    else
-        [, key, mods] = Gtk.accelerator_parse(accelerator);
+            row.add_suffix(shortcutLabel);
+            row.activatable_widget = shortcutLabel;
+            group.add(row);
+        });
 
-    let row = model.insert(100);
-    model.set(row, [COLUMN_ID, COLUMN_DESC, COLUMN_KEY, COLUMN_MODS], [id, description, key, mods]);
-}
+        window.add(page);
+    };
+};
+
+const keyvalIsForbidden$1 = (keyval) => {
+    return [
+        Gdk.KEY_Home,
+        Gdk.KEY_Page_Up,
+        Gdk.KEY_Page_Down,
+        Gdk.KEY_End,
+        Gdk.KEY_Tab,
+        Gdk.KEY_KP_Enter,
+        Gdk.KEY_Return,
+        Gdk.KEY_Mode_switch,
+        Gdk.KEY_Space,
+    ].includes(keyval);
+};
+
+const isValidAccel$1 = (mask, keyval) => {
+    return (
+        Gtk.accelerator_valid(keyval, mask) ||
+        (keyval === Gdk.KEY_Tab && mask !== 0)
+    );
+};
+
+const isValidBinding$1 = (mask, keycode, keyval) => {
+    return (
+        mask !== 0 &&
+        keycode !== 0 &&
+        mask & ~(Gdk.ModifierType.SHIFT_MASK) &&
+        !(keyvalIsForbidden$1(keyval))
+    );
+};


### PR DESCRIPTION
This a huge PR so here's a breakdown:

# GNOME 45

The import statements have been adapted to ESM standards (instead the custom import system used by GNOME Shell until version 44). In addition, the preferences window has been ported to libadwaita: 

![Screenshot from 2023-09-30 22-57-32](https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer/assets/65264536/c2a840c4-b17f-481a-87cb-ac755ed32bb8)

# i18n (Translations)

The extension now supports translations! I added a translation to my mother language as a "demo":

![image](https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer/assets/65264536/fcb508c0-43b2-46e9-a0d2-0ed0e619e819)

# Use center of windows for relative positioning

Instead of using the top left corner of the windows to position them relative to each other, use their centers. This yields a more intuitive behavior in cases like the one below. Both `focus-down` and `focus-right` will move the focus from the small window to the big window, which was not the case before this commit:

![image](https://github.com/martinhjartmyr/gnome-shell-extension-focus-changer/assets/65264536/9edcb06f-7c75-4ce4-8567-d424824af906)


# Donations

I added a Ko-fi link to `metadata.json`, as https://extensions.gnome.org has gained support for donation links.