### PR TITLE
Sort windows by user time

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -143,8 +143,8 @@ export default class FocusChanger extends Extension {
         const y = this._getCenterY(activeRect);
         let bestCandidate = null;
 
-	// Sort windows such that most recently used window is first (ie. near the top)
-        windows.sort((a, b) => (b.user_time - a.user_time));
+        // Sort windows such that most recently used window is first (ie. near the top)
+        windows.sort((a, b) => b.user_time - a.user_time);
 
         switch (id) {
             case SCHEMA_FOCUS_UP:

--- a/extension.js
+++ b/extension.js
@@ -143,6 +143,9 @@ export default class FocusChanger extends Extension {
         const y = this._getCenterY(activeRect);
         let bestCandidate = null;
 
+	// Sort windows such that most recently used window is first (ie. near the top)
+        windows.sort((a, b) => (b.user_time - a.user_time));
+
         switch (id) {
             case SCHEMA_FOCUS_UP:
                 windows.forEach(w => {


### PR DESCRIPTION
When switching monitors, we would sometimes focus a covered window (ie. a window hidden underneath another window), which makes focus changing a bit jarring.

This modification sorts the candidate windows by the user_time attribute whereby a higher user_time means that the window was more recently interactive with (and thus more likely to be in the foreground).

This is based on the isAbove function from Adjacent-Windows:

    https://github.com/klangman/Adjacent-Windows/blob/81fa84757c820df2456e3f5d145d2b8670c4777b/adjacent-windows%40klangman/5.4/extension.js#L44

This should help address issue: #4 